### PR TITLE
ci: update GitHub Actions to latest majors

### DIFF
--- a/.github/actions/gradle-setup/action.yml
+++ b/.github/actions/gradle-setup/action.yml
@@ -9,4 +9,8 @@ runs:
         distribution: temurin
         java-version: 21
 
-    - uses: gradle/actions/setup-gradle@v4
+    - uses: gradle/actions/setup-gradle@v6
+      with:
+        # Use the open-source (MIT) cache provider built on @actions/cache,
+        # not the proprietary "Enhanced Caching" default introduced in v6.
+        cache-provider: basic

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -38,7 +38,7 @@ jobs:
 
       - name: Generate deploy token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.DOCS_APP_ID }}
           private-key: ${{ secrets.DOCS_APP_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -39,7 +39,7 @@ jobs:
 
       - name: Create GitHub Release
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           name: ${{ github.ref_name }}
           generate_release_notes: true


### PR DESCRIPTION
Updates all GitHub Actions to their latest major versions.

| Action | From | To |
|---|---|---|
| `actions/checkout` | v4 | **v6** |
| `actions/create-github-app-token` | v2 | **v3** |
| `softprops/action-gh-release` | v2 | **v3** |
| `gradle/actions/setup-gradle` | v4 | **v6** |

`actions/setup-java` (v5) and `peaceiris/actions-gh-pages` (v4) are already on their latest major.

### Notes
- The v6/v3 majors only move the runtime to **Node 24** — no input changes, and all our usages (`fetch-depth`, `app-id`/`private-key`, `name`/`files`) are unchanged.
- **gradle/actions v6 caching:** v6 makes the default *Enhanced Caching* a proprietary, closed-source component (`gradle-actions-caching` — free for public repos, but under Gradle's Terms of Use). This PR pins the `gradle-setup` composite to the **open-source MIT `cache-provider: basic`** (built on `@actions/cache`) to avoid the proprietary dependency.

### Validation
- This PR's **Build** run exercises `checkout@v6` + the `gradle-setup` composite (`setup-gradle@v6` + basic caching).
- `create-github-app-token@v3` (docs) and `action-gh-release@v3` (release) don't run on PRs — verified input-compatible from their v3 changelogs (Node-24-only majors, inputs unchanged).
