### PR TITLE
build(deps): bump safe dependency versions (Kotlin, Dokka, MockK, slf4j)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-kotlin = "2.3.0"
-dokka = "2.1.0"
+kotlin = "2.3.21"
+dokka = "2.2.0"
 mavenPublish = "0.36.0"
 axionRelease = "1.21.1"
 
@@ -12,8 +12,8 @@ velocityApi = "3.4.0"
 adventurePlatform = "4.4.1"
 snakeyamlEngine = "3.0.1"
 junitJupiter = "5.14.2"
-mockk = "1.14.7"
-slf4j = "2.0.17"
+mockk = "1.14.11"
+slf4j = "2.0.18"
 jsonassert = "1.5.3"
 
 [plugins]


### PR DESCRIPTION
Safe patch/minor dependency bumps — no code changes. Verified locally with `./gradlew build dokkaGeneratePublicationHtml` (compile + tests + KDoc generation all green).

| Dependency | From | To |
|---|---|---|
| Kotlin | `2.3.0` | `2.3.21` |
| Dokka | `2.1.0` | `2.2.0` |
| MockK (test) | `1.14.7` | `1.14.11` |
| slf4j-api | `2.0.17` | `2.0.18` |

### Held back deliberately
- **JUnit `5.14.2` → `6.1.0`** — major version (test-only but breaking); deferred.
- **Minecraft/Paper-coupled**: `paper-api`, `bungeecord-api`, `brigadier`, and `adventure` (4.x → 5.x). These track the target Minecraft/Paper version, and adventure is provided by the platform at runtime — so they should move together as a deliberate "support newer Minecraft" change, not a routine bump.
