### PR TITLE
ci: pin mkdocs-material to major version 9

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Build MkDocs
         run: |
           python -m pip install --upgrade pip
-          python -m pip install mkdocs-material
+          python -m pip install 'mkdocs-material>=9,<10'
           mkdocs build -f docs/mkdocs.yml
 
       - name: Add KDoc and extra files to site


### PR DESCRIPTION
## What

Constrain the docs-build dependency in `.github/workflows/docs.yml`:

```diff
-          python -m pip install mkdocs-material
+          python -m pip install 'mkdocs-material>=9,<10'
```

## Why

The docs build installed `mkdocs-material` unpinned, so any future **10.x** major release would be picked up automatically on the next docs push. A breaking major could silently break `mkdocs build` and publish broken output to `kraftlin.github.io`.

`>=9,<10` keeps CI on the newest **9.x** (minor + patch updates still flow through, currently 9.7.6) while ruling out an untested major bump.

## Notes

- No effect until merged — `docs.yml` only runs on push to `main` / tags.
- Dokka (`libs.versions.toml`) stays exact-pinned, which is the right convention for the Gradle build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)