### PR TITLE
ci: add Dependabot config (Gradle deps/plugins + GitHub Actions)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+version: 2
+updates:
+  # Gradle version catalog: libraries + build plugins (Kotlin, Dokka, vanniktech,
+  # axion-release) via their version refs, plus test/runtime libs.
+  # Minecraft/Paper-coupled deps are intentionally ignored — their versions must
+  # track the target Paper/MC platform (which provides them at runtime), so they
+  # are bumped deliberately as part of a "support newer Minecraft" change, never
+  # automatically. NOTE: Dependabot's `gradle` ecosystem does NOT reliably bump the
+  # Gradle wrapper itself (gradle-wrapper.properties) — that's tracked separately.
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "build"
+    groups:
+      gradle-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    ignore:
+      - dependency-name: "io.papermc.paper:*"     # paper-api
+      - dependency-name: "com.velocitypowered:*"  # velocity-api
+      - dependency-name: "net.md-5:*"             # bungeecord-api
+      - dependency-name: "net.kyori:adventure*"   # adventure: api, serializers, platform
+      - dependency-name: "com.mojang:brigadier"   # brigadier (ships with the platform)
+
+  # GitHub Actions in workflows AND the local gradle-setup composite action
+  # (Dependabot does not scan .github/actions/ unless the folder is listed).
+  - package-ecosystem: "github-actions"
+    directories:
+      - "/"
+      - "/.github/actions/gradle-setup"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+    groups:
+      actions:
+        patterns: ["*"]


### PR DESCRIPTION
Adds `.github/dependabot.yml` for weekly, grouped dependency updates.

### Covered
- **`gradle`** — version-catalog libraries + build plugins (Kotlin, Dokka, vanniktech-publish, axion-release) via their version refs. Minor/patch updates are **grouped into one weekly PR**; majors come as individual PRs.
- **`github-actions`** — workflow files **and** the local `gradle-setup` composite action (Dependabot ignores `.github/actions/` unless the folder is listed explicitly, so it's added under `directories`).

### Intentionally ignored (Minecraft/Paper-coupled)
These track the target Paper/MC version (which provides them at runtime), so they're bumped deliberately as a "support newer Minecraft" change — never automatically:
`io.papermc.paper:*`, `com.velocitypowered:*`, `net.md-5:*`, `net.kyori:adventure*`, `com.mojang:brigadier`.

### Not covered (honest gaps)
- **Gradle wrapper** — Dependabot's `gradle` ecosystem updates *dependencies/plugins*, not the wrapper distribution (`gradle-wrapper.properties`); its wrapper support is limited/unreliable. The dedicated tool is the scheduled [`gradle-update/update-gradle-wrapper-action`](https://github.com/gradle-update/update-gradle-wrapper-action) — happy to add it in a follow-up if you want guaranteed wrapper PRs.
- **mkdocs-material** — installed inline in `docs.yml`, which isn't a manifest Dependabot can read (skipped per your call).

> Note: Dependabot reads `dependabot.yml` from the **default branch**, so it activates after this merges (then runs on the weekly schedule, or via the "Check for updates" button in Insights → Dependency graph → Dependabot).
