### PR TITLE
ci: automate Gradle wrapper updates

### DIFF
--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -1,0 +1,26 @@
+name: Update Gradle Wrapper
+
+# The one update Dependabot's `gradle` ecosystem does NOT cover: the Gradle
+# wrapper itself (gradle-wrapper.properties / .jar). Opens a PR when a newer
+# Gradle ships. Wrapper *checksum validation* is already done on every build by
+# gradle/actions/setup-gradle@v6 (validate-wrappers defaults to true), so no
+# separate wrapper-validation step is needed here.
+on:
+  schedule:
+    - cron: "0 6 * * 1" # weekly, Monday 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-gradle-wrapper:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
+      - uses: gradle-update/update-gradle-wrapper-action@v2


### PR DESCRIPTION
Automates the one update Dependabot can't: the **Gradle wrapper** itself.

Adds `.github/workflows/update-gradle-wrapper.yml` — a weekly (+ `workflow_dispatch`) job using [`gradle-update/update-gradle-wrapper-action@v2`](https://github.com/gradle-update/update-gradle-wrapper-action) that opens a PR when a newer Gradle ships. It **self-verifies** by running the build with the new wrapper, and **pins the distribution SHA-256** by default (supply-chain hardening).

### Why no separate validation step
`gradle/actions/setup-gradle@v6` (in the `gradle-setup` composite) **already validates the wrapper JAR checksum** against known-good Gradle releases on every build — `validate-wrappers` has defaulted to `true` since v4. So the supply-chain validation angle is covered; adding `gradle/actions/wrapper-validation` would be redundant.

### Caveat
Uses the default `GITHUB_TOKEN`, so the auto-generated wrapper PR won't trigger `build.yml` (GitHub's loop-prevention). Mitigated by the action's built-in verification; you can also re-run Build manually on the PR. (A PAT/App token would restore auto-CI if you want it later.)

Activates after merge; `workflow_dispatch` it to confirm — it'll no-op cleanly since the wrapper is already on 9.5.1 (current).
